### PR TITLE
"feat/bundle-init-cleanup had recent pushes — Compare & pull request"

### DIFF
--- a/ehr_medallion_pipeline/.gitignore
+++ b/ehr_medallion_pipeline/.gitignore
@@ -1,0 +1,11 @@
+.databricks/
+build/
+dist/
+__pycache__/
+*.egg-info
+.venv/
+scratch/**
+!scratch/README.md
+**/explorations/**
+**/!explorations/README.md
+.vscode/

--- a/ehr_medallion_pipeline/databricks.yml
+++ b/ehr_medallion_pipeline/databricks.yml
@@ -1,0 +1,46 @@
+# This is a Databricks asset bundle definition for ehr_medallion_pipeline.
+# See https://docs.databricks.com/dev-tools/bundles/index.html for documentation.
+bundle:
+  name: ehr_medallion_pipeline
+  uuid: a0b4c9eb-542f-401f-8791-5921a4848a23
+
+include:
+  - resources/*.yml
+
+artifacts:
+  python_artifact:
+    type: whl
+    build: uv build --wheel
+
+# Variable declarations. These variables are assigned in the dev/prod targets below.
+variables:
+  catalog:
+    description: The catalog to use
+  schema:
+    description: The schema to use
+
+targets:
+  dev:
+    # The default target uses 'mode: development' to create a development copy.
+    # - Deployed resources get prefixed with '[dev my_user_name]'
+    # - Any job schedules and triggers are paused by default.
+    # See also https://docs.databricks.com/dev-tools/bundles/deployment-modes.html.
+    mode: development
+    default: true
+    workspace:
+      host: https://dbc-f6207e3f-04b5.cloud.databricks.com
+    variables:
+      catalog: ehr_pipeline
+      schema: dev
+  prod:
+    mode: production
+    workspace:
+      host: https://dbc-f6207e3f-04b5.cloud.databricks.com
+      # We explicitly deploy to /Workspace/Users/aytekin.fatihm@gmail.com to make sure we only have a single copy.
+      root_path: /Workspace/Users/aytekin.fatihm@gmail.com/.bundle/${bundle.name}/${bundle.target}
+    variables:
+      catalog: ehr_pipeline
+      schema: prod
+    permissions:
+      - user_name: aytekin.fatihm@gmail.com
+        level: CAN_MANAGE

--- a/ehr_medallion_pipeline/fixtures/.gitkeep
+++ b/ehr_medallion_pipeline/fixtures/.gitkeep
@@ -1,0 +1,9 @@
+# Test fixtures directory
+
+Add JSON or CSV files here. In tests, use them with `load_fixture()`:
+
+```
+def test_using_fixture(load_fixture):
+    data = load_fixture("my_data.json")
+    assert len(data) >= 1
+```

--- a/ehr_medallion_pipeline/pyproject.toml
+++ b/ehr_medallion_pipeline/pyproject.toml
@@ -1,0 +1,31 @@
+[project]
+name = "ehr_medallion_pipeline"
+version = "0.0.1"
+authors = [{ name = "aytekin.fatihm@gmail.com" }]
+requires-python = ">=3.10,<3.13"
+dependencies = [
+    # Any dependencies for jobs and pipelines in this project can be added here
+    # See also https://docs.databricks.com/dev-tools/bundles/library-dependencies
+    #
+    # LIMITATION: for pipelines, dependencies are cached during development;
+    # add dependencies to the 'environment' section of your pipeline.yml file instead
+]
+
+[dependency-groups]
+dev = [
+    "pytest",
+    "ruff",
+    "databricks-dlt",
+    "databricks-connect>=15.4,<15.5",
+    "ipykernel",
+]
+
+[project.scripts]
+main = "ehr_medallion_pipeline.main:main"
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.ruff]
+line-length = 120

--- a/ehr_medallion_pipeline/resources/ehr_medallion_pipeline_etl.pipeline.yml
+++ b/ehr_medallion_pipeline/resources/ehr_medallion_pipeline_etl.pipeline.yml
@@ -1,0 +1,20 @@
+# The main pipeline for ehr_medallion_pipeline
+
+resources:
+  pipelines:
+    ehr_medallion_pipeline_etl:
+      name: ehr_medallion_pipeline_etl
+      catalog: ${var.catalog}
+      schema: bronze
+      serverless: true
+      root_path: "../src/ehr_medallion_pipeline_etl"
+
+      libraries:
+        - glob:
+            include: ../src/ehr_medallion_pipeline_etl/transformations/**
+
+      environment:
+        dependencies:
+          # We include every dependency defined by pyproject.toml by defining an editable environment
+          # that points to the folder where pyproject.toml is deployed.
+          - --editable ${workspace.file_path}

--- a/ehr_medallion_pipeline/resources/ehr_pipeline_job.job.yml
+++ b/ehr_medallion_pipeline/resources/ehr_pipeline_job.job.yml
@@ -1,0 +1,54 @@
+# A sample job for ehr_medallion_pipeline.
+
+resources:
+  jobs:
+    sample_job:
+      name: sample_job
+
+      trigger:
+        # Run this job every day, exactly one day from the last run; see https://docs.databricks.com/api/workspace/jobs/create#trigger
+        periodic:
+          interval: 1
+          unit: DAYS
+
+      #email_notifications:
+      #  on_failure:
+      #    - your_email@example.com
+
+      parameters:
+        - name: catalog
+          default: ${var.catalog}
+        - name: schema
+          default: ${var.schema}
+
+      tasks:
+        - task_key: notebook_task
+          notebook_task:
+            notebook_path: ../src/sample_notebook.ipynb
+        - task_key: python_wheel_task
+          depends_on:
+            - task_key: notebook_task
+          python_wheel_task:
+            package_name: ehr_medallion_pipeline
+            entry_point: main
+            parameters:
+              - "--catalog"
+              - "${var.catalog}"
+              - "--schema"
+              - "${var.schema}"
+          environment_key: default
+        - task_key: refresh_pipeline
+          depends_on:
+            - task_key: notebook_task
+          pipeline_task:
+            pipeline_id: ${resources.pipelines.ehr_medallion_pipeline_etl.id}
+
+      environments:
+        - environment_key: default
+          spec:
+            environment_version: "4"
+            dependencies:
+              # By default we just include the .whl file generated for the ehr_medallion_pipeline package.
+              # See https://docs.databricks.com/dev-tools/bundles/library-dependencies.html
+              # for more information on how to add other libraries.
+              - ../dist/*.whl

--- a/ehr_medallion_pipeline/src/bronze_ingestion.ipynb
+++ b/ehr_medallion_pipeline/src/bronze_ingestion.ipynb
@@ -1,0 +1,149 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {},
+     "inputWidgets": {},
+     "nuid": "ee353e42-ff58-4955-9608-12865bd0950e",
+     "showTitle": false,
+     "title": ""
+    }
+   },
+   "source": [
+    "# Default notebook\n",
+    "\n",
+    "This default notebook is executed using a Lakeflow job as defined in resources/sample_job.job.yml."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {},
+     "inputWidgets": {},
+     "nuid": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+     "showTitle": false,
+     "title": ""
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# Set default catalog and schema\n",
+    "catalog = dbutils.widgets.get(\"catalog\")\n",
+    "schema = dbutils.widgets.get(\"schema\")\n",
+    "spark.sql(f\"USE CATALOG {catalog}\")\n",
+    "spark.sql(f\"USE SCHEMA {schema}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
+     "inputWidgets": {},
+     "nuid": "6bca260b-13d1-448f-8082-30b60a85c9ae",
+     "showTitle": false,
+     "title": ""
+    }
+   },
+   "outputs": [],
+   "source": [
+    "import sys\n",
+    "\n",
+    "sys.path.append(\"../src\")\n",
+    "from ehr_medallion_pipeline import taxis\n",
+    "\n",
+    "taxis.find_all_taxis().show(10)"
+   ]
+  }
+ ],
+ "metadata": {
+  "application/vnd.databricks.v1+notebook": {
+   "dashboards": [],
+   "environmentMetadata": {
+    "base_environment": "",
+    "dependencies": [
+     "--editable .."
+    ],
+    "environment_version": "4"
+   },
+   "language": "python",
+   "notebookMetadata": {
+    "pythonIndentUnit": 2
+   },
+   "notebookName": "notebook",
+   "widgets": {
+    "catalog": {
+     "currentValue": "ehr_pipeline",
+     "nuid": "c4t4l0g-w1dg-3t12-3456-789012345678",
+     "typedWidgetInfo": {
+      "autoCreated": false,
+      "defaultValue": "ehr_pipeline",
+      "label": "Catalog",
+      "name": "catalog",
+      "options": {
+       "validationRegex": null,
+       "widgetDisplayType": "Text"
+      },
+      "parameterDataType": "String"
+     },
+     "widgetInfo": {
+      "defaultValue": "ehr_pipeline",
+      "label": "Catalog",
+      "name": "catalog",
+      "options": {
+       "autoCreated": false,
+       "validationRegex": null,
+       "widgetType": "text"
+      },
+      "widgetType": "text"
+     }
+    },
+    "schema": {
+     "currentValue": "aytekin_fatihm",
+     "nuid": "5ch3m4-w1dg-3t98-7654-321098765432",
+     "typedWidgetInfo": {
+      "autoCreated": false,
+      "defaultValue": "default",
+      "label": "Schema",
+      "name": "schema",
+      "options": {
+       "validationRegex": null,
+       "widgetDisplayType": "Text"
+      },
+      "parameterDataType": "String"
+     },
+     "widgetInfo": {
+      "defaultValue": "default",
+      "label": "Schema",
+      "name": "schema",
+      "options": {
+       "autoCreated": false,
+       "validationRegex": null,
+       "widgetType": "text"
+      },
+      "widgetType": "text"
+     }
+    }
+   }
+  },
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}

--- a/ehr_medallion_pipeline/src/ehr_medallion_pipeline/main.py
+++ b/ehr_medallion_pipeline/src/ehr_medallion_pipeline/main.py
@@ -1,0 +1,24 @@
+import argparse
+from databricks.sdk.runtime import spark
+from ehr_medallion_pipeline import taxis
+
+
+def main():
+    # Process command-line arguments
+    parser = argparse.ArgumentParser(
+        description="Databricks job with catalog and schema parameters",
+    )
+    parser.add_argument("--catalog", required=True)
+    parser.add_argument("--schema", required=True)
+    args = parser.parse_args()
+
+    # Set the default catalog and schema
+    spark.sql(f"USE CATALOG {args.catalog}")
+    spark.sql(f"USE SCHEMA {args.schema}")
+
+    # Example: just find all taxis from a sample catalog
+    taxis.find_all_taxis().show(5)
+
+
+if __name__ == "__main__":
+    main()

--- a/ehr_medallion_pipeline/tests/conftest.py
+++ b/ehr_medallion_pipeline/tests/conftest.py
@@ -1,0 +1,94 @@
+"""This file configures pytest, initializes Databricks Connect, and provides fixtures for Spark and loading test data."""
+
+import os, sys, pathlib
+from contextlib import contextmanager
+
+
+try:
+    from databricks.connect import DatabricksSession
+    from databricks.sdk import WorkspaceClient
+    from pyspark.sql import SparkSession
+    import pytest
+    import json
+    import csv
+    import os
+except ImportError:
+    raise ImportError(
+        "Test dependencies not found.\n\nRun tests using 'uv run pytest'. See http://docs.astral.sh/uv to learn more about uv."
+    )
+
+
+@pytest.fixture()
+def spark() -> SparkSession:
+    """Provide a SparkSession fixture for tests.
+
+    Minimal example:
+        def test_uses_spark(spark):
+            df = spark.createDataFrame([(1,)], ["x"])
+            assert df.count() == 1
+    """
+    return DatabricksSession.builder.getOrCreate()
+
+
+@pytest.fixture()
+def load_fixture(spark: SparkSession):
+    """Provide a callable to load JSON or CSV from fixtures/ directory.
+
+    Example usage:
+
+        def test_using_fixture(load_fixture):
+            data = load_fixture("my_data.json")
+            assert data.count() >= 1
+    """
+
+    def _loader(filename: str):
+        path = pathlib.Path(__file__).parent.parent / "fixtures" / filename
+        suffix = path.suffix.lower()
+        if suffix == ".json":
+            rows = json.loads(path.read_text())
+            return spark.createDataFrame(rows)
+        if suffix == ".csv":
+            with path.open(newline="") as f:
+                rows = list(csv.DictReader(f))
+            return spark.createDataFrame(rows)
+        raise ValueError(f"Unsupported fixture type for: {filename}")
+
+    return _loader
+
+
+def _enable_fallback_compute():
+    """Enable serverless compute if no compute is specified."""
+    conf = WorkspaceClient().config
+    if conf.serverless_compute_id or conf.cluster_id or os.environ.get("SPARK_REMOTE"):
+        return
+
+    url = "https://docs.databricks.com/dev-tools/databricks-connect/cluster-config"
+    print("☁️ no compute specified, falling back to serverless compute", file=sys.stderr)
+    print(f"  see {url} for manual configuration", file=sys.stdout)
+
+    os.environ["DATABRICKS_SERVERLESS_COMPUTE_ID"] = "auto"
+
+
+@contextmanager
+def _allow_stderr_output(config: pytest.Config):
+    """Temporarily disable pytest output capture."""
+    capman = config.pluginmanager.get_plugin("capturemanager")
+    if capman:
+        with capman.global_and_fixture_disabled():
+            yield
+    else:
+        yield
+
+
+def pytest_configure(config: pytest.Config):
+    """Configure pytest session."""
+    with _allow_stderr_output(config):
+        _enable_fallback_compute()
+
+        # Initialize Spark session eagerly, so it is available even when
+        # SparkSession.builder.getOrCreate() is used. For DB Connect 15+,
+        # we validate version compatibility with the remote cluster.
+        if hasattr(DatabricksSession.builder, "validateSession"):
+            DatabricksSession.builder.validateSession().getOrCreate()
+        else:
+            DatabricksSession.builder.getOrCreate()


### PR DESCRIPTION
## What this does
  - Removes taxi sample files generated by bundle init
  - Renames sample_job to ehr_pipeline_job
  - Sets catalog: ehr_pipeline, schema: bronze as DLT default
  - Configures dev/prod targets in databricks.yml

  ## No logic changes — configuration and cleanup only