### PR TITLE
Feat/bronze healthverity ingestion

### DIFF
--- a/ehr_medallion_pipeline/config/dev.yml
+++ b/ehr_medallion_pipeline/config/dev.yml
@@ -21,3 +21,4 @@ healthverity:
   source_table: "samples.healthverity.claims_sample_synthetic"
   source_prefix: "hv"
   target_schema: "bronze"
+  target_table: "claims_raw"

--- a/ehr_medallion_pipeline/src/ehr_medallion_pipeline/bronze/ingest_healthverity.py
+++ b/ehr_medallion_pipeline/src/ehr_medallion_pipeline/bronze/ingest_healthverity.py
@@ -1,0 +1,28 @@
+from pyspark.sql import functions as F
+from ehr_medallion_pipeline.utils import load_config
+
+def ingest_healthverity(spark, env: str = "dev"):
+    """
+    Ingest HealthVerity claims table into Bronze Delta table.
+
+    Args:
+        spark: Active SparkSession
+        env:   Environment name e.g. 'dev' or 'prod'
+    """
+    cfg = load_config(env)
+    source_table = cfg["healthverity"]["source_table"]
+    source_prefix = cfg["healthverity"]["source_prefix"]
+    target = f"{cfg['catalog']}.bronze"
+    target_table = cfg["healthverity"]["target_table"]
+
+    df = spark.read.table(source_table)
+
+    df = df.withColumn("_ingested_at", F.current_timestamp())
+    df = df.withColumn("_source_file", F.lit(source_table))
+
+    df.write \
+        .format("delta") \
+        .mode("append") \
+        .saveAsTable(f"{target}.{source_prefix}_{target_table}")
+        
+    print(f"{source_prefix}_{target_table} ingested successfully.")


### PR DESCRIPTION
HealthVerity claims ingested into ehr_pipeline.bronze.hv_claims_raw
409,825 rows. Production code tested and verified.

closes #6