### PR TITLE
Adds four enrichment columns to the Silver HealthVerity claims transform (closes #21)

### DIFF
--- a/ehr_medallion_pipeline/src/ehr_medallion_pipeline/silver/transform_hv_claims.py
+++ b/ehr_medallion_pipeline/src/ehr_medallion_pipeline/silver/transform_hv_claims.py
@@ -1,7 +1,26 @@
 from pyspark.sql import functions as F
+from pyspark.sql.functions import broadcast
 from pyspark.sql import Window
 from pyspark.sql.types import DecimalType
 from ehr_medallion_pipeline.utils import load_config
+
+
+# ICD-10 first-character → diagnosis category lookup
+ICD10_CATEGORY_MAP = {
+    "A": "Infectious Diseases", "B": "Infectious Diseases",
+    "C": "Neoplasms / Blood Diseases", "D": "Neoplasms / Blood Diseases",
+    "E": "Endocrine / Metabolic", "F": "Mental / Behavioral",
+    "G": "Nervous System", "H": "Eye / Ear",
+    "I": "Circulatory System", "J": "Respiratory",
+    "K": "Digestive", "L": "Skin",
+    "M": "Musculoskeletal", "N": "Genitourinary",
+    "O": "Pregnancy", "P": "Perinatal",
+    "Q": "Congenital", "R": "Abnormal Findings",
+    "S": "Injury / Poisoning", "T": "Injury / Poisoning",
+    "V": "External Causes", "W": "External Causes",
+    "X": "External Causes", "Y": "External Causes",
+    "Z": "Health Services / Factors",
+}
 
 
 def transform_hv_claims(spark, env: str = "dev"):
@@ -14,6 +33,10 @@ def transform_hv_claims(spark, env: str = "dev"):
     - Cast patient_year_of_birth to integer
     - Cast service_line_number to integer
     - Derive patient_age from birth year
+    - Decode ICD-10 first character to diagnosis_category (broadcast join)
+    - Derive cost_reduction (line_charge - line_allowed)
+    - Decode claim_type (P → Professional, I → Institutional)
+    - Validate NPI format (is_valid_npi flag)
     - Generate surrogate key (claim_line_id) via MD5 hash
     - Deduplicate by claim_line_id keeping latest ingestion
     - Add _silver_processed_at audit column
@@ -45,7 +68,30 @@ def transform_hv_claims(spark, env: str = "dev"):
         F.year(F.current_date()) - F.col("patient_year_of_birth")
     )
 
-    # 5. surrogate key — composite of claim line identity
+    # 5. diagnosis_category — broadcast join on ICD-10 first character
+    icd10_items = [(k, v) for k, v in ICD10_CATEGORY_MAP.items()]
+    icd10_df = spark.createDataFrame(icd10_items, ["icd10_letter", "diagnosis_category"])
+
+    df = df.withColumn("icd10_letter", F.substring(F.col("diagnosis_code"), 1, 1))
+    df = df.join(broadcast(icd10_df), on="icd10_letter", how="left")
+
+    # 6. cost reduction — difference between billed and allowed
+    df = df.withColumn("cost_reduction", F.col("line_charge") - F.col("line_allowed"))
+
+    # 7. decode claim type
+    df = df.withColumn("claim_type_decoded",
+        F.when(F.col("claim_type") == "P", "Professional")
+         .when(F.col("claim_type") == "I", "Institutional")
+         .otherwise(None)
+    )
+
+    # 8. validate NPI format — must be exactly 10 digits
+    df = df.withColumn("is_valid_npi",
+        F.when(F.col("prov_rendering_npi").rlike("^\\d{10}$"), True)
+         .otherwise(False)
+    )
+
+    # 9. surrogate key — composite of claim line identity
     df = df.withColumn(
         "claim_line_id",
         F.md5(F.concat_ws("_",
@@ -55,13 +101,13 @@ def transform_hv_claims(spark, env: str = "dev"):
         ))
     )
 
-    # 6. dedup — keep latest ingestion per claim line
+    # 10. dedup — keep latest ingestion per claim line
     window = Window.partitionBy("claim_line_id").orderBy(F.col("_ingested_at").desc())
     df = df.withColumn("_row_rank", F.row_number().over(window)) \
            .filter(F.col("_row_rank") == 1) \
            .drop("_row_rank")
 
-    # 7. audit column
+    # 11. audit column
     df = df.withColumn("_silver_processed_at", F.current_timestamp())
 
     # write to silver


### PR DESCRIPTION
## Changes
- `diagnosis_category` — ICD-10 first character decoded via broadcast join
- `cost_reduction` — line_charge minus line_allowed
- `claim_type_decoded` — P → Professional, I → Institutional
- `is_valid_npi` — regex validation of 10-digit NPI format
- `icd10_letter` — retained as helper column for Gold filtering

## Validation
- Row count unchanged: 327,788
- Enrichments verified against sample data