### PR TITLE
feat: schema drift detection with registry and drift log

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,17 +94,17 @@ Cleaned, typed, deduplicated, and enriched. All tables in `ehr_pipeline.silver`.
 - `is_valid_npi` — regex validation (`^\d{10}$`)
 - `DecimalType(10,2)` for monetary columns to avoid floating-point precision drift
 
-### Gold Layer (In Progress)
+### Gold Layer (Complete)
 
 Analytical aggregates built with dbt, materialized as Delta tables in `ehr_pipeline.gold`.
 
 | Model | Grain | Status |
 |-------|-------|--------|
 | patient_summary | 1 row per patient | ✅ Complete |
-| encounter_summary | 1 row per encounter-condition | 🔨 In progress |
-| condition_prevalence | 1 row per condition code | Planned |
-| provider_metrics | 1 row per provider | Planned |
-| readmission_risk | 1 row per encounter | Planned |
+| encounter_summary | 1 row per encounter-condition | ✅ Complete |
+| condition_prevalence | 1 row per condition code | ✅ Complete |
+| provider_metrics | 1 row per provider | ✅ Complete |
+| readmission_risk | 1 row per encounter | ✅ Complete |
 
 **Design decisions:**
 - PySpark for Bronze/Silver (complex ingestion, window functions, programmatic control)
@@ -125,6 +125,8 @@ Analytical aggregates built with dbt, materialized as Delta tables in `ehr_pipel
 **DecimalType over float/double** — Fixed-point arithmetic for monetary columns to prevent precision drift in aggregations.
 
 **PII protection** — SSN, drivers license, passport dropped in Silver. Maiden name excluded from Gold. No PII in analytical tables.
+
+**Schema drift detection** — Baseline schema captured in Delta registry table. On each run, current schema compared via set operations (left_anti joins). Three drift types detected: columns added, removed, or type changed. Drift events logged with timestamps for audit.
 
 ## Running the Pipeline
 
@@ -165,7 +167,7 @@ Databricks SQL dashboard built over Gold layer tables.
 
 - [x] Complete Gold dbt models (encounter_summary, condition_prevalence, provider_metrics, readmission_risk)
 - [x] Databricks SQL dashboard over Gold tables
-- [ ] Schema drift detection on Bronze layer
+- [x] Schema drift detection on Bronze layer
 - [ ] Genie AI agent for natural language queries over Gold
 - [ ] dbt tests and documentation for Gold models
 

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -132,3 +132,11 @@ _ingested_at > last_watermark.
 - Materialization: table (not view — Gold serves dashboards and AI agents)
 - Sources defined in _sources.yml pointing to all 7 Silver tables
 - dbt run --select <model> for targeted builds (avoids unnecessary rebuilds)
+
+### Schema drift detection (Issue #10)
+- Baseline stored in ehr_pipeline.bronze.schema_registry (Delta table)
+- Delta chosen over config file — queryable, automatable, auditable
+- detect_drift() uses left_anti joins for set comparison
+- Drift log is append-only — preserves full history
+- Registry uses delete + append per schema to avoid cross-schema overwrites
+- Checks both Bronze (188 columns, 15 tables) and Silver (137 columns, 7 tables)

--- a/ehr_medallion_pipeline/src/ehr_medallion_pipeline/utils/schema_drift.py
+++ b/ehr_medallion_pipeline/src/ehr_medallion_pipeline/utils/schema_drift.py
@@ -53,12 +53,22 @@ def capture_schema(spark, catalog: str, schema_name: str, env: str = "dev"):
     registry_df = registry_df.withColumn("_registered_at", F.current_timestamp()) \
                              .withColumn("updated_at", F.current_timestamp())
 
-    # write to registry — overwrite to refresh baseline
-    registry_df.write \
-        .format("delta") \
-        .mode("overwrite") \
-        .option("overwriteSchema", "true") \
-        .saveAsTable(registry_table)
+    # write to registry — delete existing rows for this schema, then append
+    # this preserves baselines for other schemas
+    if spark.catalog.tableExists(registry_table):
+        from delta.tables import DeltaTable
+        delta_table = DeltaTable.forName(spark, registry_table)
+        delta_table.delete(F.col("schema_name") == schema_name)
+        registry_df.write \
+            .format("delta") \
+            .mode("append") \
+            .saveAsTable(registry_table)
+    else:
+        registry_df.write \
+            .format("delta") \
+            .mode("overwrite") \
+            .option("overwriteSchema", "true") \
+            .saveAsTable(registry_table)
 
     print(f"Schema registry captured: {len(rows)} columns across {len(tables)} tables in {schema_name}")
     return registry_df

--- a/ehr_medallion_pipeline/src/ehr_medallion_pipeline/utils/schema_drift.py
+++ b/ehr_medallion_pipeline/src/ehr_medallion_pipeline/utils/schema_drift.py
@@ -1,0 +1,191 @@
+from pyspark.sql import functions as F
+from pyspark.sql.types import StructType, StructField, StringType, BooleanType
+from ehr_medallion_pipeline.utils import load_config
+
+
+def capture_schema(spark, catalog: str, schema_name: str, env: str = "dev"):
+    """
+    Capture the current schema of all tables in a given schema
+    and write to the schema_registry table.
+
+    This establishes the baseline that detect_drift() compares against.
+    Run once to create the baseline, re-run to refresh after approved changes.
+
+    Args:
+        spark:       Active SparkSession
+        catalog:     Catalog name e.g. 'ehr_pipeline'
+        schema_name: Schema to scan e.g. 'bronze'
+        env:         Environment name
+    """
+    registry_table = f"{catalog}.bronze.schema_registry"
+
+    # list all tables in the schema
+    tables = spark.catalog.listTables(f"{catalog}.{schema_name}")
+
+    rows = []
+    for table in tables:
+        full_name = f"{catalog}.{schema_name}.{table.name}"
+        try:
+            df = spark.table(full_name)
+            for field in df.schema.fields:
+                rows.append((
+                    schema_name,
+                    table.name,
+                    field.name,
+                    str(field.dataType).replace("Type", "").lower(),
+                    field.nullable
+                ))
+        except Exception as e:
+            print(f"Warning: could not read schema for {full_name}: {e}")
+
+    # create dataframe from collected rows
+    schema = StructType([
+        StructField("schema_name", StringType(), False),
+        StructField("table_name", StringType(), False),
+        StructField("column_name", StringType(), False),
+        StructField("data_type", StringType(), False),
+        StructField("is_nullable", BooleanType(), False),
+    ])
+
+    registry_df = spark.createDataFrame(rows, schema)
+
+    # add audit timestamps
+    registry_df = registry_df.withColumn("_registered_at", F.current_timestamp()) \
+                             .withColumn("updated_at", F.current_timestamp())
+
+    # write to registry — overwrite to refresh baseline
+    registry_df.write \
+        .format("delta") \
+        .mode("overwrite") \
+        .option("overwriteSchema", "true") \
+        .saveAsTable(registry_table)
+
+    print(f"Schema registry captured: {len(rows)} columns across {len(tables)} tables in {schema_name}")
+    return registry_df
+
+
+def detect_drift(spark, catalog: str, schema_name: str, env: str = "dev"):
+    """
+    Compare current schema of all tables against the baseline
+    stored in schema_registry. Log any differences to schema_drift_log.
+
+    Detects three types of drift:
+    - COLUMN_ADDED:   column exists now but not in baseline
+    - COLUMN_REMOVED: column in baseline but missing now
+    - TYPE_CHANGED:   column exists in both but data type differs
+
+    Args:
+        spark:       Active SparkSession
+        catalog:     Catalog name e.g. 'ehr_pipeline'
+        schema_name: Schema to check e.g. 'bronze'
+        env:         Environment name
+    """
+    registry_table = f"{catalog}.bronze.schema_registry"
+    drift_log_table = f"{catalog}.bronze.schema_drift_log"
+
+    # load baseline
+    baseline_df = spark.table(registry_table) \
+        .filter(F.col("schema_name") == schema_name) \
+        .select("schema_name", "table_name", "column_name", "data_type", "is_nullable")
+
+    # capture current schema
+    tables = spark.catalog.listTables(f"{catalog}.{schema_name}")
+
+    current_rows = []
+    for table in tables:
+        full_name = f"{catalog}.{schema_name}.{table.name}"
+        try:
+            df = spark.table(full_name)
+            for field in df.schema.fields:
+                current_rows.append((
+                    schema_name,
+                    table.name,
+                    field.name,
+                    str(field.dataType).replace("Type", "").lower(),
+                    field.nullable
+                ))
+        except Exception as e:
+            print(f"Warning: could not read schema for {full_name}: {e}")
+
+    current_schema = StructType([
+        StructField("schema_name", StringType(), False),
+        StructField("table_name", StringType(), False),
+        StructField("column_name", StringType(), False),
+        StructField("data_type", StringType(), False),
+        StructField("is_nullable", BooleanType(), False),
+    ])
+
+    current_df = spark.createDataFrame(current_rows, current_schema)
+
+    # --- detect drift ---
+
+    join_keys = ["schema_name", "table_name", "column_name"]
+
+    # columns added (in current but not in baseline)
+    added_df = current_df.join(baseline_df, on=join_keys, how="left_anti") \
+        .withColumn("drift_type", F.lit("COLUMN_ADDED")) \
+        .withColumn("old_value", F.lit(None).cast("string")) \
+        .withColumn("new_value", F.col("data_type")) \
+        .select("schema_name", "table_name", "column_name", "drift_type", "old_value", "new_value")
+
+    # columns removed (in baseline but not in current)
+    removed_df = baseline_df.join(current_df, on=join_keys, how="left_anti") \
+        .withColumn("drift_type", F.lit("COLUMN_REMOVED")) \
+        .withColumn("old_value", F.col("data_type")) \
+        .withColumn("new_value", F.lit(None).cast("string")) \
+        .select("schema_name", "table_name", "column_name", "drift_type", "old_value", "new_value")
+
+    # type changes (column exists in both but data_type differs)
+    type_changed_df = current_df.alias("curr").join(
+        baseline_df.alias("base"),
+        on=join_keys,
+        how="inner"
+    ).filter(
+        F.col("curr.data_type") != F.col("base.data_type")
+    ).select(
+        F.col("curr.schema_name"),
+        F.col("curr.table_name"),
+        F.col("curr.column_name"),
+        F.lit("TYPE_CHANGED").alias("drift_type"),
+        F.col("base.data_type").alias("old_value"),
+        F.col("curr.data_type").alias("new_value"),
+    )
+
+    # combine all drift events
+    drift_df = added_df.union(removed_df).union(type_changed_df)
+
+    # add detection timestamp
+    drift_df = drift_df.withColumn("_detected_at", F.current_timestamp())
+
+    drift_count = drift_df.count()
+
+    if drift_count > 0:
+        # append to drift log (preserve history)
+        drift_df.write \
+            .format("delta") \
+            .mode("append") \
+            .option("mergeSchema", "true") \
+            .saveAsTable(drift_log_table)
+
+        print(f"⚠️  Schema drift detected: {drift_count} changes in {schema_name}")
+        drift_df.show(truncate=False)
+    else:
+        print(f"✅ No schema drift detected in {schema_name}")
+
+    return drift_df
+
+
+def run_drift_check(spark, env: str = "dev"):
+    """
+    Run schema drift detection across all pipeline schemas.
+
+    Args:
+        spark: Active SparkSession
+        env:   Environment name
+    """
+    cfg = load_config(env)
+    catalog = cfg["catalog"]
+
+    for schema_name in ["bronze", "silver"]:
+        print(f"\n--- Checking {schema_name} ---")
+        detect_drift(spark, catalog, schema_name, env)


### PR DESCRIPTION
Adds automated schema drift detection for Bronze and Silver layers (closes #10).

## What it does
- capture_schema() — scans all tables in a schema, stores column names/types/nullable flags in schema_registry
- detect_drift() — compares current schema against baseline, detects COLUMN_ADDED, COLUMN_REMOVED, TYPE_CHANGED
- run_drift_check() — convenience function to check both Bronze and Silver
- Drift events appended to schema_drift_log table with timestamps

## Tables created
- ehr_pipeline.bronze.schema_registry (188 Bronze + 137 Silver = 325 column baselines)
- ehr_pipeline.bronze.schema_drift_log (append-only audit trail)

## Fix included
- Registry uses Delta delete + append per schema instead of full overwrite
- Prevents one schema capture from wiping another schema's baseline